### PR TITLE
fix: some mis typing, wrong operator key value

### DIFF
--- a/src/spaceone/inventory/conf/cloud_service_conf.py
+++ b/src/spaceone/inventory/conf/cloud_service_conf.py
@@ -61,7 +61,7 @@ REGION_INFO = {
                        'tags': {'latitude': '37.528547', 'longitude': '126.871867', 'continent': 'asia_pacific'}},
     'ap-southeast-1': {'name': 'Asia Pacific (Singapore)',
                        'tags': {'latitude': '1.321259', 'longitude': '103.695942', 'continent': 'asia_pacific'}},
-    'ap-southeast-2	': {'name': 'Asia Pacific (Sydney)',
+    'ap-southeast-2': {'name': 'Asia Pacific (Sydney)',
                         'tags': {'latitude': '-33.921423', 'longitude': '151.188076', 'continent': 'asia_pacific'}},
     'ap-northeast-1': {'name': 'Asia Pacific (Tokyo)',
                        'tags': {'latitude': '35.648411', 'longitude': '139.792566', 'continent': 'asia_pacific'}},

--- a/src/spaceone/inventory/connector/aws_lightsail_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_lightsail_connector/connector.py
@@ -203,6 +203,7 @@ class LightsailConnector(SchematicAWSConnector):
                 yield {
                     'data': bucket,
                     'name': bucket.name,
+                    'instance_size': size,
                     'account': self.account_id
                 }
 

--- a/src/spaceone/inventory/connector/aws_lightsail_connector/schema/service_type.py
+++ b/src/spaceone/inventory/connector/aws_lightsail_connector/schema/service_type.py
@@ -331,10 +331,10 @@ cst_ip._metadata = CloudServiceTypeMeta.set_meta(
     fields=[
         TextDyField.data_source('Name', 'name'),
         TextDyField.data_source('IP Address', 'data.ip_address'),
-        TextDyField.data_source('Is Attached', 'data.is_attached', default_badge={
+        EnumDyField.data_source('Is Attached', 'data.is_attached', default_badge={
             'indigo.500': ['true'], 'coral.600': ['false']
         }),
-        EnumDyField.data_source('Attached to ', 'data.attached_to'),
+        TextDyField.data_source('Attached To ', 'data.attached_to'),
         TextDyField.data_source('ARN', 'data.arn', options={
             'is_optional': True
         }),

--- a/src/spaceone/inventory/connector/aws_lightsail_connector/schema/widget/rdb_total_cpu_count.yaml
+++ b/src/spaceone/inventory/connector/aws_lightsail_connector/schema/widget/rdb_total_cpu_count.yaml
@@ -1,13 +1,14 @@
 ---
 cloud_service_group: Lightsail
 cloud_service_type: Database
-name: Total Count
+name: Total CPU Count
 query:
   aggregate:
     - group:
         fields:
           - name: value
-            operator: data.hardware.cpu_count
+            key: data.hardware.cpu_count
+            operator: sum
 options:
   value_options:
     key: value

--- a/src/spaceone/inventory/connector/aws_lightsail_connector/schema/widget/rdb_total_disk_size.yaml
+++ b/src/spaceone/inventory/connector/aws_lightsail_connector/schema/widget/rdb_total_disk_size.yaml
@@ -1,13 +1,14 @@
 ---
 cloud_service_group: Lightsail
 cloud_service_type: Database
-name: Total Count
+name: Total Disk Size
 query:
   aggregate:
     - group:
         fields:
           - name: value
-            operator: data.hardware.disk_size_in_gb
+            key: data.hardware.disk_size_in_gb
+            operator: sum
 options:
   value_options:
     key: value

--- a/src/spaceone/inventory/connector/aws_lightsail_connector/schema/widget/rdb_total_memory_size.yaml
+++ b/src/spaceone/inventory/connector/aws_lightsail_connector/schema/widget/rdb_total_memory_size.yaml
@@ -1,15 +1,18 @@
 ---
 cloud_service_group: Lightsail
 cloud_service_type: Database
-name: Total Count
+name: Total Memory Size
 query:
   aggregate:
     - group:
         fields:
           - name: value
-            operator: data.hardware.ram_size_in_gb
+            key: data.hardware.ram_size_in_gb
+            operator: sum
 options:
   value_options:
     key: value
+    type: size
     options:
+      source_unit: GB
       default: 0


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Updated mis typing in region_info(cloud_service_conf.py). Resources in 'ap-southeaset-2' doss not have region name. 
- Updated wrong widget query in aws lightsail

### Known issue