### PR TITLE
add exclude region list (ap-east-1) for Lightsail

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img width="245" src="https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/aws-cloudservice.svg">
   <p> 
     <br>
-    <img alt="Version"  src="https://img.shields.io/badge/version-1.13.10-blue.svg?cacheSeconds=2592000"  />    
+    <img alt="Version"  src="https://img.shields.io/badge/version-1.13.11-blue.svg?cacheSeconds=2592000"  />    
     <a href="https://www.apache.org/licenses/LICENSE-2.0"  target="_blank"><img alt="License: Apache 2.0"  src="https://img.shields.io/badge/License-Apache 2.0-yellow.svg" /></a> 
   </p> 
 </div>    
@@ -16,7 +16,7 @@
 
 
 Find us also at [Dockerhub](https://hub.docker.com/repository/docker/spaceone/plugin-aws-cloud-service-inven-collector)
-> Latest stable version : 1.13.10
+> Latest stable version : 1.13.11
 
 Please contact us if you need any further information. (<support@spaceone.dev>)
 
@@ -374,6 +374,10 @@ The `service_code_mappers` items that can be specified are as follows.
 ---
 
 ## Release Note
+
+### Ver 1.13.11
+* Exclude Region for Collecting a Lightsail (ap-east-1) [#440](https://github.com/spaceone-dev/plugin-aws-cloud-service-inven-collector/issues/440)
+* Add sleep for avoid API Rate Limitation for collecting a API Gatway resource [#441](https://github.com/spaceone-dev/plugin-aws-cloud-service-inven-collector/issues/441)
 
 ### Ver 1.13.10
 * Update RDS Filter (add Postgresql Aurora)

--- a/src/spaceone/inventory/connector/aws_api_gateway_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_api_gateway_connector/connector.py
@@ -69,6 +69,9 @@ class APIGatewayConnector(SchematicAWSConnector):
             for raw in data.get('items', []):
                 try:
                     _res = self.client.get_resources(restApiId=raw.get('id'), limit=500)
+                    # for avoid to API Rate limitation.
+                    time.sleep(0.5)
+
                     raw.update({
                         'protocol': 'REST',
                         'endpoint_type': self.get_endpoint_type(raw.get('endpointConfiguration', {}).get('types')),

--- a/src/spaceone/inventory/connector/aws_lightsail_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_lightsail_connector/connector.py
@@ -16,7 +16,7 @@ from spaceone.inventory.connector.aws_lightsail_connector.schema.service_type im
 from spaceone.inventory.libs.connector import SchematicAWSConnector
 
 _LOGGER = logging.getLogger(__name__)
-EXCLUDE_REGION = ['ap-northeast-3', 'sa-east-1', 'us-west-1', 'me-south-1']
+EXCLUDE_REGION = ['ap-northeast-3', 'sa-east-1', 'us-west-1', 'me-south-1', 'ap-east-1']
 
 
 class LightsailConnector(SchematicAWSConnector):


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
fix: add exclude region list (ap-east-1) for Lightsail
fix: add sleep for avoid to API Rate limitation for API Gateway resources

### Known issue
Collecting Error: Could not connect to the endpoint URL: "https://lightsail.ap-east-1.amazonaws.com/" #440 
Collecting Error: An error occurred (TooManyRequestsException) when calling the GetResources operation (reached max retries: 4): Too Many Requests #441 
