### PR TITLE
Exclude Region list for some cloud service (Lightsail, DocumentDB)

### DIFF
--- a/src/spaceone/inventory/connector/aws_documentdb_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_documentdb_connector/connector.py
@@ -10,7 +10,7 @@ from spaceone.inventory.connector.aws_documentdb_connector.schema.service_type i
 from spaceone.inventory.libs.connector import SchematicAWSConnector
 
 _LOGGER = logging.getLogger(__name__)
-EXCLUDE_REGION = ['us-west-1', 'ap-east-1', 'eu-north-1', 'me-south-1', 'sa-east-1', 'ap-northeast-3']
+EXCLUDE_REGION = ['us-west-1', 'af-south-1', 'ap-east-1', 'ap-southeast-3', 'ap-northeast-3', 'eu-north-1', 'me-south-1']
 
 
 class DocumentDBConnector(SchematicAWSConnector):

--- a/src/spaceone/inventory/connector/aws_lightsail_connector/connector.py
+++ b/src/spaceone/inventory/connector/aws_lightsail_connector/connector.py
@@ -16,7 +16,7 @@ from spaceone.inventory.connector.aws_lightsail_connector.schema.service_type im
 from spaceone.inventory.libs.connector import SchematicAWSConnector
 
 _LOGGER = logging.getLogger(__name__)
-EXCLUDE_REGION = ['ap-northeast-3', 'sa-east-1', 'us-west-1', 'me-south-1', 'ap-east-1']
+EXCLUDE_REGION = ['ap-northeast-3', 'sa-east-1', 'us-west-1', 'me-south-1', 'ap-east-1', 'af-south-1', 'eu-south-1']
 
 
 class LightsailConnector(SchematicAWSConnector):


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Add exclude region list (Lightsail, DocumentDB)

### Known issue
* could not connect to the endpoint URL: "https://lightsail.eu-south-1.amazonaws.com/" (#446) 
* An error occurred (InvalidParameterValue) when calling the DescribeDBClusters operation: Unrecognized engine name: docdb (#447) 